### PR TITLE
보드 업데이트시 불필요한 퀴리 및 태그 변경 감지 로직 변경

### DIFF
--- a/src/main/java/com/myboard/aop/valid/NotEmptyValidator.java
+++ b/src/main/java/com/myboard/aop/valid/NotEmptyValidator.java
@@ -19,7 +19,6 @@ public class NotEmptyValidator implements ConstraintValidator<NotEmptyList, List
 
     @Override
     public boolean isValid(List<String> values, ConstraintValidatorContext context) {
-        log.info("NotEmptyValidator");
         return !CollectionUtils.isEmpty(values);
     }
 }

--- a/src/main/java/com/myboard/controller/board/BoardController.java
+++ b/src/main/java/com/myboard/controller/board/BoardController.java
@@ -54,7 +54,7 @@ public class BoardController {
     @PreAuthorize("hasRole('USER')")
     @PutMapping("/board/{boardId}/update")
     public ResponseEntity<Long> updateBoard(@Valid @RequestBody UpdateBoardDto updateBoardDto,
-                                            @PathVariable("boardId") Long boardId,
+                                            @CheckExist(type = EntityType.BOARD, message = "B003") @PathVariable("boardId") Long boardId,
                                             @CurrentLoginUserId Long userId) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(boardService.updateBoard(updateBoardDto, boardId, userId));
@@ -66,7 +66,7 @@ public class BoardController {
     @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/board/{boardId}/delete")
     public ResponseEntity<Long> deleteBoard(@CheckExist(type = EntityType.BOARD, message = "B003") @PathVariable("boardId") Long boardId,
-                                         @CurrentLoginUserId Long userId) {
+                                            @CurrentLoginUserId Long userId) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(boardService.deleteBoard(boardId, userId));
     }

--- a/src/main/java/com/myboard/repository/board/BoardRepository.java
+++ b/src/main/java/com/myboard/repository/board/BoardRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryEx {
 
-    @Query("SELECT b.id FROM Board b WHERE b.id = :boardId AND b.user.id = :userId")
-    Optional<Long> findIdByUserIdAndBoardId(@Param("boardId") Long boardId, @Param("userId") Long userId);
+    @Query("SELECT b FROM Board b WHERE b.id = :boardId AND b.user.id = :userId")
+    Optional<Board> findIdByUserIdAndBoardId(@Param("boardId") Long boardId, @Param("userId") Long userId);
 
 }

--- a/src/main/java/com/myboard/util/filter/LoginFilter.java
+++ b/src/main/java/com/myboard/util/filter/LoginFilter.java
@@ -48,6 +48,7 @@ public class LoginFilter extends OncePerRequestFilter {
                 .orElseThrow(UserNotFoundException::new);
 
         httpSession.setAttribute("USER_ID", userId);
+        httpSession.setMaxInactiveInterval(600);
     }
 
     @Override

--- a/src/test/java/com/myboard/service/BoardServiceTest.java
+++ b/src/test/java/com/myboard/service/BoardServiceTest.java
@@ -1,6 +1,7 @@
 package com.myboard.service;
 
 import com.myboard.dto.requestDto.board.CreateBoardDto;
+import com.myboard.dto.requestDto.board.UpdateBoardDto;
 import com.myboard.dto.responseDto.article.ArticleResponseDto;
 import com.myboard.dto.responseDto.board.BoardResponseDto;
 import com.myboard.entity.Board;
@@ -103,6 +104,13 @@ public class BoardServiceTest {
                 .build();
     }
 
+    private UpdateBoardDto getUpdateBoardDto() {
+        return UpdateBoardDto.builder()
+                .boardName("test")
+                .tagNames(Arrays.asList("test1", "test2"))
+                .build();
+    }
+
     private BoardResponseDto boardDetailResponse() {
         List<ArticleResponseDto> articleResponseList = new ArrayList<>();
 
@@ -177,4 +185,24 @@ public class BoardServiceTest {
         then(boardRepository).should(never()).save(board);
     }
 
+    @Test
+    @WithMockUser
+    @DisplayName("게시판 수정 성공")
+    void updateBoardSuccessful() throws Exception {
+        UpdateBoardDto request = getUpdateBoardDto();
+
+//        given(boardRepository.findById(BOARD_ID))
+//                .willReturn(any());
+
+        doReturn(Optional.of(board)).when(boardRepository).findById(BOARD_ID);
+
+        given(boardRepository.findIdByUserIdAndBoardId(BOARD_ID, USER_ID))
+                .willReturn(any());
+
+        // when
+        boardService.updateBoard(request, BOARD_ID, USER_ID);
+
+        // then
+        then(boardRepository).should(times(1)).save(any());
+    }
 }


### PR DESCRIPTION
보드 업데이트시 중복 조회문 삭제 및 기존 태그가 없을시 변경 쿼리 나감, 기존 태그가 있을시 새로운 태그와의 변화를 체크한 후 변경 쿼리 나가도록 코드 변경